### PR TITLE
Added support for service_name property

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -63,7 +63,7 @@ spec:
       {%- for path in route.paths %}
       - path: {{ path }}
         backend:
-          serviceName: {{ route.name }}
+          serviceName: {{ route.get('service_name') or route.name }}
           servicePort: 80
       {% endfor %}
       {% endfor %}

--- a/templates/site.yaml
+++ b/templates/site.yaml
@@ -2,9 +2,11 @@
 
 {% if "routes" in data %}
 {%- for route in data.routes %}
-  {%- with app_name=route.name, data=route %}
-    {%- include 'service.yaml' %}
-  {% endwith %}
+  {%- if route.service_name is not defined %}
+    {%- with app_name=route.name, data=route %}
+      {%- include 'service.yaml' %}
+    {% endwith %}
+  {% endif %}
 {% endfor %}
 {% endif %}
 
@@ -12,9 +14,11 @@
 
 {% if "routes" in data %}
 {%- for route in data.routes %}
-  {%- with app_name=route.name, data=route %}
-    {%- include 'deployment.yaml' %}
-  {% endwith %}
+  {%- if route.service_name is not defined %}
+    {%- with app_name=route.name, data=route %}
+      {%- include 'deployment.yaml' %}
+    {% endwith %}
+  {% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
## Done

- Added support for service_name property, fixes #3 

## QA

1. `snap install konf`
2. Checkout this PR https://github.com/canonical-web-and-design/ubuntu.com/pull/8891
3. `konf production konf/site.yaml > ~/output1.yaml`
4. Checkout this branch
5. `./konf.py production ../ubuntu.com/konf/site.yaml > ~/output2.yaml`
6. `diff ~/output1.yaml ~/output2.yaml`

`output2.yaml` shouldn't have the Service and Deployment objects