### PR TITLE
Remove .ubuntu.com rule from NO_PROXY

### DIFF
--- a/templates/proxy-settings.yaml
+++ b/templates/proxy-settings.yaml
@@ -5,4 +5,4 @@
   value: "http://squid.internal:3128/"
 
 - name: NO_PROXY
-  value: ".internal,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io"
+  value: ".internal,ubuntu.com,certification.ubuntu.com,discourse.ubuntu.com,login.ubuntu.com,partners.ubuntu.com,admin.insights.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io"


### PR DESCRIPTION
We need to proxy for some ubuntu.com domains so I am removing the generic rule
and replacing it with subdomains for which we don't want to proxy.

Fixes https://github.com/canonical-web-and-design/deployment-configs/issues/400