### PR TITLE
Include memoryLimit property

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -83,3 +83,5 @@ spec:
           resources:
             limits:
               memory: {{ data.memoryLimit | default("256Mi") }}
+            requests:
+              memory: {{ data.memoryRequest | default("128Mi") }}


### PR DESCRIPTION
_From [Kubernetes docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits):_
> If a Container specifies its own memory limit, but does not specify a memory request, Kubernetes automatically assigns a memory request that matches the limit

##  Done
- Added `memoryRequest` propery with a default value of `128Mi`

## QA

In any of our webteam projects `./konf.py production sites/snapcraft.io.yaml --local-qa  | microk8s.kubectl apply -f -`