### PR TITLE
Upgrade to use core20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+*.snap

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: konf
-base: core18
+base: core20
 
 version: git
 
@@ -31,6 +31,6 @@ parts:
 
 apps:
   konf:
-    command: konf.py
+    command: bin/konf.py
     plugs:
       - home


### PR DESCRIPTION
# summary

bump core version to core20

# qa

- `snapcraft`
- `snap install --dangerous konf_0+git.c19b7b1-dirty_amd64.snap`
- Go on canonical.com repo (or any other)
- `konf staging konf/site.yaml`
- Should work as before