### PR TITLE
Revert "Fix python missing glibc error"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -26,8 +26,6 @@ parts:
   konf-python:
     source: .
     plugin: python
-    build-packages:
-      - gcc-multilib
 
 apps:
   konf:


### PR DESCRIPTION
This reverts commit 11bebf1c24a12da4e51a1329cd65670d61fbbacb.