### PR TITLE
Quote labels to avoid config errors when label is numeric

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -6,9 +6,9 @@ metadata:
   name: {{ data.get('name') or get_site_name() }}
   namespace: {{ namespace }}
   labels:
-    app: {{ data.get('app_name') or domain }}
+    app: "{{ data.get('app_name') or domain }}"
     {%- for key, value in labels.items() %}
-    {{key}}: {{value}}
+    {{key}}: "{{value}}"
     {%- endfor %}
 spec:
   replicas: {{ data.replicas }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -20,9 +20,9 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     {%- endif %}
   labels:
-    app: {{ data.get('app_name') or domain }}
+    app: "{{ data.get('app_name') or domain }}"
     {%- for key, value in labels.items() %}
-    {{key}}: {{value}}
+    {{key}}: "{{value}}"
     {%- endfor %}
 
 spec:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -6,9 +6,9 @@ metadata:
   name: {{ data.get('name') or get_site_name() }}
   namespace: {{ namespace }}
   labels:
-    app: {{ data.get('app_name') or domain }}
+    app: "{{ data.get('app_name') or domain }}"
     {%- for key, value in labels.items() %}
-    {{key}}: {{value}}
+    {{key}}: "{{value}}"
     {%- endfor %}
 spec:
   selector:


### PR DESCRIPTION
# Done
Quote labels to avoid config errors when label is numeric

# QA
- checkout the branch
-  echo "image: nginx:latest" > site.yaml
-  ./konf.py demo site.yaml -o domain=nginx.demos.haus -l github.pr=1552
-  check all `metadata.labels` are quoted