### PR TITLE
upgrade jinja to 3.1.x

### DIFF
--- a/konf.py
+++ b/konf.py
@@ -12,7 +12,7 @@ TEMPLATES_DIR = BASE_DIR + "/templates"
 
 
 # Custom Jinja2 functions
-@jinja2.contextfunction
+@jinja2.pass_context
 def get_site_name(context, add_staging_prefix=False):
     """Return the metadata name to use for the K8s objects."""
     domain = context["domain"].split(".")
@@ -30,7 +30,7 @@ def get_site_name(context, add_staging_prefix=False):
     return "-".join(domain)
 
 
-@jinja2.contextfunction
+@jinja2.pass_context
 def get_environment_domain(context):
     """Return the environment domain."""
     domain = context["domain"]
@@ -45,7 +45,7 @@ def get_environment_domain(context):
     return domain
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def add_environment_prefix(context, s):
     """Return the domain with the staging prefix if needed."""
     domain = s.split(".")
@@ -56,7 +56,7 @@ def add_environment_prefix(context, s):
     return ".".join(domain)
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def is_apex_domain(context, s):
     """Check if the given string is an apex/base domain"""
     return s.count(".") == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyYAML==5.4.1
-Jinja2==2.11.3
+PyYAML==6.0
+Jinja2==3.1.1


### PR DESCRIPTION
## Done

- Upgrade Jinja2 from 2.x.x to 3.1.x
- Upgrade PyYaml from 5.x.x to 6.0.0

## QA

- Download a konf file:
```bash
# in the PR's directory
wget https://github.com/canonical-web-and-design/ubuntu.com/blob/main/konf/site.yaml
```
- Setup venv
- Run 2 konf commands:
```bash
konf staging site.yaml > current.yaml && ./konf.py staging site.yaml > dev.yaml
```
- Compare the 2 outputs:
```bash
diff current.yaml dev.yaml
```
- Make sure there is no output (it means that there is no difference in output)
- Repeat the last 3 steps for production:
```bash
konf production site.yaml > current.yaml && ./konf.py production site.yaml > dev.yaml
diff current.yaml dev.yaml
# expected result: no output from the diff command
```
