### PR TITLE
fix DATABASE_URL filtering

### DIFF
--- a/konf.py
+++ b/konf.py
@@ -90,7 +90,7 @@ class Konf:
             # Replace database URL in main deployment and in routes
             def _replace_database_url(envs, database_url):
                 for index, env in enumerate(envs):
-                    if "DATABASE_URL" in env["name"]:
+                    if "DATABASE_URL" == env["name"]:
                         envs.pop(index)
                         break
                 envs.append({"name": "DATABASE_URL", "value": database_url})


### PR DESCRIPTION
## Done

- Change the filtering condition for the override option on the env variable `DATABASE_URL`

## QA

- Install python dependencies:
```bash
python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
```
- Copy this konf sample to `test.yaml`:
```yaml
domain: hiring.canonical.com

image: test

env:
  - name: WORKPLACE_ENGINEERING_DATABASE_URL
    secretKeyRef:
      key: workplace_engineering_database_url
      name: hiring-databases

demo:
  env:
    - name: WORKPLACE_ENGINEERING_DATABASE_URL
      secretKeyRef:
        key: workplace_engineering_database_url
        name: hiring-com
```
- Run the following command:
```bash
python3 ./konf.py demo test.yaml > result.yaml
```
- Make sure that the env variable `WORKPLACE_ENGINEERING_DATABASE_URL` is present in the `result.yaml` file

## Issues

Fixes #26 
