### PR TITLE
Fix Konf output for demos

### DIFF
--- a/konf.py
+++ b/konf.py
@@ -184,6 +184,15 @@ class KonfSite(Konf):
 
         self.values = yaml.load(self.values_file, Loader=yaml.FullLoader)
 
+        # Use staging overrides for demos
+        if self.deployment_env == "demo":
+            staging_values = self.values.get("staging", {})
+            staging_values.pop("routes", None)
+            staging_values.pop("nginxConfigurationSnippet", None)
+            staging_values.pop("nginxServerSnippet", None)
+
+            self.values.update(staging_values)
+
         for override in self.overrides:
             key, value = override.split("=")
             self.values[key] = value
@@ -196,10 +205,6 @@ class KonfSite(Konf):
 
         # Set deployment environment namespace
         self.namespace = self.deployment_env
-
-        # Use staging overrides for demos
-        if self.deployment_env == "demo":
-            self.values.update(self.values.get("staging", {}))
 
         # QA overrides
         if self.local_qa or self.deployment_env == "demo":


### PR DESCRIPTION
## Done

- Konf was returning values for staging (introduced on [#21](https://github.com/canonical-web-and-design/konf/pull/21)) that we shouldn't set for demos

## QA
Install current konf with: `sudo snap install konf`
Check out this branch and compare that both outputs for demos are the same, eg:
```bash
konf demo ../../Workspace/snapcraft.io/konf/site.yaml --database-url postgres://postgres:POSTGRES_PW@postgres:5432/DATABASE_NAME -o domain=DEMO_DOMAIN image=IMAGE_NAME tlsName=demos-haus secretKey=demos-haus -l github.org=REPO_ORG github.repo=REPO_NAME github.pr=PR --tag IMAGE_TAG > a.yaml

./konf.py demo ../../Workspace/snapcraft.io/konf/site.yaml --database-url postgres://postgres:POSTGRES_PW@postgres:5432/DATABASE_NAME -o domain=DEMO_DOMAIN image=IMAGE_NAME tlsName=demos-haus secretKey=demos-haus -l github.org=REPO_ORG github.repo=REPO_NAME github.pr=PR --tag IMAGE_TAG > b.yaml

diff a.yaml b.yaml
```

The `diff` output should be empty