### PR TITLE
Extend env section

### DIFF
--- a/konf.py
+++ b/konf.py
@@ -201,7 +201,20 @@ class KonfSite(Konf):
         self.domain = self.values["domain"]
 
         # Environment overrides
-        self.values.update(self.values.get(self.deployment_env, {}))
+        environment_config = self.values.get(self.deployment_env, {})
+
+        # Extend the env section instead of overriding it
+        if environment_config.get("env") and self.values.get("env"):
+            env_names = [e["name"] for e in environment_config["env"]]
+
+            # If the same value is defined in the general section and
+            # in the environment section, we discard the general one in
+            # favour of the environment (production,staging,demo) value
+            for item in self.values["env"]:
+                if item["name"] not in env_names:
+                    environment_config["env"].append(item)
+
+        self.values.update(environment_config)
 
         # Set deployment environment namespace
         self.namespace = self.deployment_env


### PR DESCRIPTION
## Issue

Konf doesn't allow to extend the secrets or environment variables for different environments (production, staging, demos). We have to redeclare the entire `env` content on each one when we want to extend it.

## Done

With these changes, we can extend our secrets easily for demos or other environments, like:
```yaml
demo:
  env:
    # change SSO team for demos
    - name: OPENID_LAUNCHPAD_TEAM
      value: canonical-content-people
```

## QA

Get this example configuration: https://pastebin.canonical.com/p/YmnSZ2Xdvt/
Run:
```
./konf.py demo file.yaml | grep OPENID_LAUNCHPAD_TEAM
```
and
```
./konf.py demo file.yaml | grep DISCOURSE_API_USERNAME
```

Both commands should return an output.