### PR TITLE
add support for k8s v1.21+ under a temporary argument

### DIFF
--- a/konf.py
+++ b/konf.py
@@ -72,6 +72,7 @@ class Konf:
         database_url,
         labels,
         overrides,
+        new_k8s_version,
     ):
         self.deployment_env = env
         self.values_file = values_file
@@ -82,7 +83,7 @@ class Konf:
         self.labels = {
             key: value for key, value in (label.split("=") for label in labels)
         }
-
+        self.new_k8s_version = new_k8s_version
         # Load project data
         self.load_values()
 
@@ -134,6 +135,7 @@ class Konf:
             labels=self.labels,
             namespace=self.namespace,
             deployment_env=self.deployment_env,
+            new_k8s_version=self.new_k8s_version,
         )
 
 
@@ -168,6 +170,8 @@ class KonfCronJob(Konf):
             self.tag = self.docker_tag
 
     def render(self, template_file="cronjob.yaml"):
+        if self.new_k8s_version:
+            template_file = "cronjob-new.yaml"
         return super(KonfCronJob, self).render(template_file)
 
 
@@ -289,6 +293,14 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         dest="labels",
+    )
+
+    # TODO: make this the default behavior once we move away from k8s < v1.21
+    parser.add_argument(
+        "--new-version",
+        action="store_true",
+        default=False,
+        dest="new_k8s_version",
     )
 
     args = vars(parser.parse_args())

--- a/templates/cronjob-new.yaml
+++ b/templates/cronjob-new.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ data.name }}
+  namespace: {{ namespace }}
+spec:
+  schedule: "{{ data.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ data.name }}
+            image: {{ data.image }}:{{ tag | default("latest", true) }}
+
+            env:
+              - name: TALISKER_NETWORKS
+                value: 10.0.0.0/8
+
+              {%- if data.useProxy is not defined or data.useProxy != False %}
+              {% macro proxy_settings() %}{% include 'proxy-settings.yaml' %}{% endmacro %}
+              {{ proxy_settings() | indent(14) }}
+              {%- endif %}
+
+              {%- if "env" in data %}
+              {%- for env in data.env %}
+              - name: {{ env.name }}
+                {%- if "value" in env %}
+                value: "{{ env.value }}"
+                {%- endif %}
+
+                {%- if "secretKeyRef" in env %}
+                valueFrom:
+                  secretKeyRef:
+                    key: {{ env.secretKeyRef.key }}
+                    name: {{ env.secretKeyRef.name }}
+                {%- endif %}
+
+                {%- if "configMapKeyRef" in env %}
+                valueFrom:
+                  configMapKeyRef:
+                    key: {{ env.configMapKeyRef.key }}
+                    name: {{ env.configMapKeyRef.name }}
+                {%- endif %}
+              {%- endfor %}
+            {%- endif %}
+
+            {%- if "run" in data %}
+            args:
+            - /bin/sh
+            - -c
+            - |
+              {{ data.run | indent(14) }}
+            {%- endif %}
+          restartPolicy: Never

--- a/templates/ingress-new.yaml
+++ b/templates/ingress-new.yaml
@@ -1,0 +1,105 @@
+---
+
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ get_site_name(True) }}
+  namespace: {{ namespace }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    {%- if "nginxConfigurationSnippet" in data %}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{ data.nginxConfigurationSnippet | indent(6) }}
+    {%- endif %}
+    {%- if "nginxServerSnippet" in data %}
+    nginx.ingress.kubernetes.io/server-snippet: |
+      {{ data.nginxServerSnippet | indent(6) }}
+    {%- endif %}
+    {%- if data.nginxSSLRedirect is defined and not data.nginxSSLRedirect %}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {%- endif %}
+  labels:
+    app: "{{ data.get('app_name') or domain }}"
+    {%- for key, value in labels.items() %}
+    {{key}}: "{{value}}"
+    {%- endfor %}
+
+spec:
+  {%- if data.noTls is not defined or not data.noTls %}
+  tls:
+  - secretName: {{ data.get('tlsName') or get_site_name(True) }}-tls
+
+    hosts:
+      - {{ get_environment_domain() }}
+    {%- if (get_environment_domain() | is_apex_domain) %}
+      - www.{{ get_environment_domain() }}
+    {%- endif %}
+
+    {%- if "extraHosts" in data %}
+    {%- for host in data.extraHosts %}
+      {%- if "useParentTLS" in host and host.useParentTLS %}
+      - {{ host.domain | add_environment_prefix }}
+      {%- if (host.domain | add_environment_prefix | is_apex_domain) %}
+      - www.{{ host.domain | add_environment_prefix }}
+      {%- endif %}
+      {%- endif %}
+    {% endfor %}
+    {%- endif %}
+  {%- endif %}
+
+  {%- if "extraHosts" in data %}
+  {%- for host in data.extraHosts %}
+  {%- if host.useParentTLS is not defined or not host.useParentTLS %}
+  - secretName: {{ host.domain | add_environment_prefix | replace(".", "-") }}-tls
+    hosts:
+      - {{ host.domain | add_environment_prefix }}
+      {%- if (host.domain | add_environment_prefix | is_apex_domain) %}
+      - www.{{ host.domain | add_environment_prefix }}
+      {%- endif %}
+  {%- endif %}
+  {% endfor %}
+  {%- endif %}
+
+  rules:
+  - host: {{ get_environment_domain() }}
+    http: &http_service
+      paths:
+      {% if "routes" in data %}
+      {%- for route in data.routes %}
+      {%- for path in route.paths %}
+      - path: {{ path }}
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ route.get('service_name') or route.name }}
+            port:
+              number: 80
+      {% endfor %}
+      {% endfor %}
+      {% endif %}
+
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ get_site_name() }}
+            port:
+              number: 80
+
+  {% if (get_environment_domain() | is_apex_domain) %}
+  - host: www.{{ get_environment_domain() }}
+    http: *http_service
+  {%- endif %}
+
+  {% if "extraHosts" in data %}
+  {% for host in data.extraHosts %}
+  - host: {{ host.domain | add_environment_prefix }}
+    http: *http_service
+
+  {%- if (host.domain | add_environment_prefix | is_apex_domain) %}
+  - host: www.{{ host.domain | add_environment_prefix }}
+    http: *http_service
+  {%- endif %}
+  {% endfor %}
+  {%- endif %}

--- a/templates/site.yaml
+++ b/templates/site.yaml
@@ -22,4 +22,8 @@
 {% endfor %}
 {% endif %}
 
-{% include 'ingress.yaml' %}
+{% if new_k8s_version %}
+  {% include 'ingress-new.yaml' %}
+{% else %}
+  {% include 'ingress.yaml' %}
+{% endif %}


### PR DESCRIPTION
## Done

- `CronJob`: migrate from `batch/v1beta1` to `batch/v1`
- `Ingress`: migrate from `networking.k8s.io/v1beta1` to `networking.k8s.io/v1`
- To use the new version, added a temporary argument: `--new-version`

## QA

### CronJob
- Download this test file: https://pastebin.canonical.com/p/9vpXDXZHZX/
- Then run: 
```bash
./konf.py production --type CronJob ./konf.yaml > a.yaml
./konf.py production --type CronJob --new-version ./konf.yaml > b.yaml

# compare both
diff  a.yaml b.yaml
```
- Make sure that the changes match what's listed in the k8s doc: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125 (not that only the `apiVersion` is changed)

### Site
- Download this test file: https://pastebin.canonical.com/p/f5FQmDqygB/
- Then run: 
```bash
./konf.py production --type Site ./konf.yaml > a.yaml
./konf.py production --type Site --new-version ./konf.yaml > b.yaml

# compare both
diff  a.yaml b.yaml
```
- Make sure that the changes match what's listed in the k8s doc: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

## Issues

Fixes #30 